### PR TITLE
ci: lock Rust nightly to 2022-03-22

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -50,7 +50,7 @@ jobs:
       - run: echo "PROTOC=$(which protoc)" >> $GITHUB_ENV
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: nightly-2022-03-22
           components: rustfmt, clippy
           override: true
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
https://github.com/paypizza/grpc-health-check/issues/3